### PR TITLE
ApcWrapper checks if apc is enabled

### DIFF
--- a/src/Illuminate/Cache/ApcWrapper.php
+++ b/src/Illuminate/Cache/ApcWrapper.php
@@ -18,6 +18,14 @@ class ApcWrapper
      */
     public function __construct()
     {
+        if (filter_var(ini_get('apc.enabled'), \FILTER_VALIDATE_BOOLEAN)) {
+            throw new RuntimeException('APC(u) is not enabled');
+        }
+
+        if (php_sapi_name() == 'cli' && !filter_var(ini_get('apc.enable_cli'), \FILTER_VALIDATE_BOOLEAN)) {
+            throw new RuntimeException('APC(u) is not enabled for CLI');
+        }
+        
         $this->apcu = function_exists('apcu_fetch');
     }
 


### PR DESCRIPTION
# Why we stumbled upon this (important)

We were using $maxExceptions for Jobs for a while now (when having endless retries set due to throttling etc jobs could be retried many times before they actually are allowed to run) with the expectation that this would work. However the first time a job was actually throwing exceptions, it would continue to do so for an endless amount of times.

After a lot of digging and debugging we figured out why. Our cache strategy has 'global' and 'local' cache. Global is set to redis, local is set to APC. Our **default cache driver was set to apc** this was the mistake.

When $maxExceptions on jobs are set, laravel will use the default cache store to remember that an exception was thrown. In our case it was using APC, however APC(u) by default is not enabled for cli. As the queue workers are in cli-mode it was writing nowhere, and throwing now exceptions whatsoever.

# What this PR is trying to fix

The false positive that we experienced was a little eye opening and we believe that if the code knows that storing something to apc will not work in any way, it should throw an exception (analog to if redis is not available or wrongly configured it will not silently do nothing, but throw an exception).

This will prevent others of running into the same false positive situation we had.

Similar discussions were made in symfony, and in their ApcuAdapter there is a 'isSupported' static which does something similar (minus the cli check)